### PR TITLE
fix: use editor.transaction() to make ayah/surah insertion undoable

### DIFF
--- a/src/FzfAyahModal.ts
+++ b/src/FzfAyahModal.ts
@@ -84,13 +84,16 @@ export class FzfAyahModal extends SuggestModal<IndexedAyah> {
       }
 
       const cursor = editor.getCursor();
-      editor.replaceRange(content, cursor);
-
       const lines = content.split("\n");
       const lastLine = lines[lines.length - 1] || "";
-      editor.setCursor({
-        line: cursor.line + lines.length - 1,
-        ch: lastLine.length,
+      editor.transaction({
+        changes: [{ from: cursor, to: cursor, text: content }],
+        selection: {
+          from: {
+            line: cursor.line + lines.length - 1,
+            ch: lastLine.length,
+          },
+        },
       });
     } catch (error) {
       console.error("Failed to insert ayah:", error);

--- a/src/FzfSurahModal.ts
+++ b/src/FzfSurahModal.ts
@@ -105,13 +105,16 @@ export class FzfSurahModal extends SuggestModal<IndexedSurah> {
       }
 
       const cursor = editor.getCursor();
-      editor.replaceRange(content, cursor);
-
       const lines = content.split("\n");
       const lastLine = lines[lines.length - 1] || "";
-      editor.setCursor({
-        line: cursor.line + lines.length - 1,
-        ch: lastLine.length,
+      editor.transaction({
+        changes: [{ from: cursor, to: cursor, text: content }],
+        selection: {
+          from: {
+            line: cursor.line + lines.length - 1,
+            ch: lastLine.length,
+          },
+        },
       });
     } catch (error) {
       console.error("Failed to insert surah:", error);


### PR DESCRIPTION
## Summary

Fixes #33

- Replace `editor.replaceRange()` + `editor.setCursor()` with `editor.transaction()` in `FzfAyahModal` and `FzfSurahModal`
- The transaction API records the insertion as a single atomic history entry, so pressing Ctrl+Z undoes the entire callout/blockquote block at once

## Root Cause

`editor.replaceRange()` is a direct CodeMirror operation that bypasses Obsidian's undo history when called outside a transaction. `editor.setCursor()` is also not tracked. Together, they leave no undoable record — hence Ctrl+Z had no effect on inserted content.

## Changes

| File | Change |
|------|--------|
| `src/FzfAyahModal.ts` | Replace `replaceRange` + `setCursor` with `editor.transaction()` |
| `src/FzfSurahModal.ts` | Replace `replaceRange` + `setCursor` with `editor.transaction()` |

## Test Plan

- [ ] Insert a single ayah → press Ctrl+Z → the inserted callout/blockquote is removed in one step
- [ ] Insert an entire surah → press Ctrl+Z → the inserted content is removed in one step
- [ ] Multiple consecutive insertions → each Ctrl+Z undoes one insertion at a time
- [ ] All 18 existing tests still pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)