### PR TITLE
fix: auto-push tag in version bump to trigger release workflow

### DIFF
--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -97,6 +97,8 @@ const main = async () => {
     `git commit -m \"chore: bump version to ${targetVersion}\" -- package.json package-lock.json manifest.json versions.json`,
   );
   runCommand(`git tag \"${targetVersion}\"`);
+  runCommand("git push");
+  runCommand(`git push origin \"${targetVersion}\"`);
 
   output.write(`Bumped version ${currentVersion} -> ${targetVersion}\n`);
 };


### PR DESCRIPTION
## Summary

Fixes #43 - Installation fails with 404 error after v1.11.0 update.

**Root cause**: The `version-bump.mjs` script creates a git tag locally but does not push it to the remote. This means the release workflow (which triggers on tag push) never runs, so no GitHub release is created and no assets (main.js, manifest.json, styles.css) are uploaded. When Obsidian tries to fetch these assets for v1.11.0, it gets a 404.

**Evidence**:
- `manifest.json` and `package.json` both show version `1.11.0`
- The commit `377524e` bumped the version to `1.11.0`
- But the tag `1.11.0` was never pushed -- `git tag --list` on the remote only goes up to `1.10.0`
- No GitHub release exists for `v1.11.0`

**Fix**: Add `git push` and `git push origin "${tag}"` to the version-bump script after tag creation, so the release workflow is triggered automatically.

## Additional recommendation

The release workflow currently creates releases with the `--draft` flag. This means even when the workflow runs successfully, the release must be manually published before Obsidian can see it. Consider removing the `--draft` flag from `.github/workflows/release.yml` to prevent this from happening again. (I was unable to include this change in this PR due to GitHub token scope restrictions for workflow files.)

## Immediate action needed

To fix the current v1.11.0 issue, the maintainer needs to manually push the tag:

```bash
git push origin 1.11.0
```

Then publish the resulting draft release on GitHub.

## Test plan

- [ ] Verify `version-bump.mjs` pushes both the commit and tag after running
- [ ] Verify the release workflow triggers after a tag push
- [ ] Verify users can install the plugin after the release is published